### PR TITLE
test

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,3 +27,14 @@ Please complete the following sections for a smooth review.
 - [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
 - [ ] The developer has manually tested the changes and verified that the changes work
 - [ ] The developer has run the integration test pipeline and verified that it passed successfully
+
+### E2E test suite update requirement
+
+When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.
+
+To opt-out of this requirement:
+1. **Inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidlines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
+2. Create opt-out justification PR comment
+   - start the comment with `## E2E update requirement opt-out justification:` title, and provide a short summary of reasons for opting-out of this requirement
+3. Edit this PR description to check the checkbox below:
+- [ ] Skip requirement to update E2E test suite for this PR

--- a/.github/workflows/check-e2e-update-requirement.yaml
+++ b/.github/workflows/check-e2e-update-requirement.yaml
@@ -1,0 +1,140 @@
+name: Check requirement to update E2E test suite
+on:
+  pull_request:
+    types: [ opened, synchronize, edited ]
+    paths:
+      - 'bundle/**'
+      - 'config/**'
+      - 'Dockerfiles/**'
+      - 'internal/**'
+      - 'pkg/**'
+      - 'cmd/main.go'
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: read
+
+jobs:
+  check-e2e-update-requirement:
+    name: Check requirement to update E2E test suite
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Check requirement to update E2E test suite
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const prNumber = context.issue.number;
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: prNumber,
+            });
+
+            const prBody = pr.body || '';
+            const skipE2eChecked = /- \[x\]\s*Skip requirement to update E2E test suite for this PR/i.test(prBody);
+            
+            console.log(`Skip e2e checkbox checked: ${skipE2eChecked}`);
+            
+            if (skipE2eChecked) {
+              console.log('Skip e2e checkbox is checked, looking for justification comment...');
+              
+              const { data: comments } = await github.rest.issues.listComments({
+                owner,
+                repo,
+                issue_number: prNumber,
+              });
+              
+              // Look for a comment from the PR author that contains justification
+              const authorComments = comments.filter(comment => 
+                comment.user.login === pr.user.login &&
+                (comment.body.includes('## E2E update requirement opt-out justification:'))
+              );
+              
+              if (authorComments.length === 0) {
+                // No justification comment from the PR author found
+                // bot hasn't posted about it yet => have it post a comment
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: prNumber,
+                  body: `## ❌ E2E Update Requirement Check Failed
+            
+            You have checked the "Skip requirement to update E2E test suite for this PR" checkbox, but no justification comment by the PR author was found.
+            
+            **Actions required from the PR author:**
+            1. Please add a comment to this PR explaining why e2e tests are not needed for this change. The skip justification comment is **required** to start with \`## E2E update requirement opt-out justification:\` title, and include a short summary of reasons for opting-out of this requirement
+            2. To re-trigger the check after adding the justification comment, you can edit the PR description in a non-disruptive way (for example, by adding a new line at the end). This event will trigger the check again, and if the justification comment is present and in the expected format, it should pass.`
+                });
+                
+                core.setFailed('❌ FAILURE: PR author opted-out of the E2E test suite update requirement, but no justification comment was found');
+                return;
+              } else {
+                console.log(`Found justification comment from PR author`);
+                console.log('✅ SUCCESS: PR author opted-out of the E2E test suite update requirement and provided a justification comment');
+              }
+            } else {
+              // skip e2e update requirement checkbox is not checked
+              // => verify e2e tests were added/updated
+              console.log('Requirement to update E2E test suite was is not set to be skipped, checking for e2e test updates in the PR...');
+              
+              const { data: files } = await github.rest.pulls.listFiles({
+                owner,
+                repo,
+                pull_number: prNumber,
+              });
+              
+              // Check if any files in tests/e2e directory were modified
+              const e2eFilesModified = files.some(file => 
+                file.filename.startsWith('tests/e2e/') && 
+                (file.status === 'added' || file.status === 'modified')
+              );
+              
+              console.log(`E2E files modified: ${e2eFilesModified}`);
+              console.log('Modified files:', files.map(f => f.filename).join(', '));
+              
+              if (!e2eFilesModified) {
+                // Check if bot already posted a comment about missing e2e tests
+                const { data: comments } = await github.rest.issues.listComments({
+                  owner,
+                  repo,
+                  issue_number: prNumber,
+                });
+
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: prNumber,
+                  body: `## ❌ E2E Update Requirement Check Failed
+            
+            No e2e tests were added/updated as part of this PR.
+            
+            **Action required from the PR author:** Please either:
+            1. Add or update e2e tests relevant to the PR changes in the \`tests/e2e/\` directory, OR
+            2. Evaluate the possibility of opting-out of this requirement:
+               1. Inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidlines.md), to determine if the nature of the PR changes allows for skipping this requirement
+               2. If opt-out is applicable, create a justification comment explaining why e2e tests are not needed for this change. This justification comment is required to start with \`## E2E update requirement opt-out justification:\` title, and include a short summary of reasons for opting-out of this requirement
+               3. To re-trigger the check after adding the justification comment, you can edit the PR description in a non-disruptive way (e.g. by adding a new line at the end)
+            
+            **Why this check exists:**
+            - E2E tests help ensure that changes work correctly in a real environment and don't break existing functionality
+            - by default, every code-related PR should include an extension/update to the E2E test suite to cover the new changes
+            - if the PR author is in doubt whether this requirement is applicable for their PR, please refer to the PR template for guidance about appropriate/inappropriate cases for opting-out`
+                });
+                
+                core.setFailed('❌ FAILURE: No e2e tests updated and skip checkbox not checked');
+                return;
+              } else {
+                console.log('✅ SUCCESS: E2E tests were added/updated in the PR');
+              }
+            }
+            
+            console.log('✅ SUCCESS: E2E requirement check passed');

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -318,6 +318,7 @@ func main() { //nolint:funlen,maintidx,gocyclo
 
 			return in, nil
 		},
+		// test comment
 	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{ // single pod does not need to have LeaderElection

--- a/docs/e2e-update-requirement-guidlines.md
+++ b/docs/e2e-update-requirement-guidlines.md
@@ -1,0 +1,32 @@
+# E2E Test Suite Update Requirement Guidelines
+
+When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly. A GitHub Action check is in place to enforce this requirement.
+
+It is possible to opt-out of this check with proper justification. Please refer to the guidelines below to determine whether your PR justifies skipping this check, and how to do it (if applicable).
+
+### Appropriate cases for opting-out of the E2E test suite update requirement:
+
+- Documentation-only changes (README, comments, etc.)
+- Unit test additions/modifications without functional changes
+- Code style/formatting changes
+- Dependency version updates without functional impact
+- Build system changes that do not affect runtime behavior
+- Non-functional refactoring with existing test coverage
+
+### NOT Appropriate cases for opting-out of E2E test suite update requirement:
+
+- New feature implementation
+- Bug fixes affecting user-facing functionality
+- API changes or modifications
+- Configuration changes affecting deployment
+- Changes to controllers, operators, or core logic
+- Cross-component integration modifications
+- Changes affecting user workflows or UI
+
+### Opt-out guide
+**Note:** This particular guide is also present in the PR template/description
+
+1. Inspect the above-mentioned guidelines, to determine if the nature of the PR changes allows for skipping this requirement
+2. Create opt-out justification PR comment
+  - start the comment with `## E2E update requirement opt-out justification:` title, and provide a short summary of reasons for opting-out of this requirement
+3. Edit the PR description to check the `Skip requirement to update E2E test suite for this PR` checkbox


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidlines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. Create opt-out justification PR comment
   - start the comment with `## E2E update requirement opt-out justification:` title, and provide a short summary of reasons for opting-out of this requirement
3. Edit this PR description to check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
