### PR TITLE
demo

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -181,7 +181,13 @@ func LoadConfig() (*OperatorConfig, error) {
 	return &operatorConfig, nil
 }
 
+func foo() {
+	fmt.Println("Trust me,I'm definitely a very important function for the Operator and totally not a placeholder")
+}
+
 func main() { //nolint:funlen,maintidx,gocyclo
+	foo()
+
 	// Viper settings
 	viper.SetEnvPrefix("ODH_MANAGER")
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))

--- a/tests/e2e/creation_test.go
+++ b/tests/e2e/creation_test.go
@@ -59,6 +59,8 @@ func dscManagementTestSuite(t *testing.T) {
 		TestContext: tc,
 	}
 
+	fooTest()
+
 	// Define test cases.
 	testCases := []TestCase{
 		{"Ensure Service Mesh , Serverless and Observability operators are installed", dscTestCtx.ValidateOperatorsInstallation},
@@ -93,6 +95,10 @@ func dscManagementTestSuite(t *testing.T) {
 
 	// Run the test suite.
 	RunTestCases(t, testCases)
+}
+
+func fooTest() {
+	fmt.Println("I'm a test function that is totally not a placeholder either")
 }
 
 // ValidateOperatorsInstallation ensures the Service Mesh and Serverless operators are installed.

--- a/tests/e2e/creation_test.go
+++ b/tests/e2e/creation_test.go
@@ -59,8 +59,6 @@ func dscManagementTestSuite(t *testing.T) {
 		TestContext: tc,
 	}
 
-	fooTest()
-
 	// Define test cases.
 	testCases := []TestCase{
 		{"Ensure Service Mesh , Serverless and Observability operators are installed", dscTestCtx.ValidateOperatorsInstallation},
@@ -95,10 +93,6 @@ func dscManagementTestSuite(t *testing.T) {
 
 	// Run the test suite.
 	RunTestCases(t, testCases)
-}
-
-func fooTest() {
-	fmt.Println("I'm a test function that is totally not a placeholder either")
 }
 
 // ValidateOperatorsInstallation ensures the Service Mesh and Serverless operators are installed.


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the section below OR as a PR comment
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR

#### E2E update requirement opt-out justification:
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
<!--- Alternatively, you can provide this justification as a comment with the same title format -->
