### PR TITLE
demo

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,3 +27,18 @@ Please complete the following sections for a smooth review.
 - [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
 - [ ] The developer has manually tested the changes and verified that the changes work
 - [ ] The developer has run the integration test pipeline and verified that it passed successfully
+
+### E2E test suite update requirement
+
+When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.
+
+To opt-out of this requirement:
+1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
+2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
+3. Check the checkbox below:
+- [ ] Skip requirement to update E2E test suite for this PR
+4. Submit/save these changes to the PR description. This will automatically trigger the check.
+
+#### E2E update requirement opt-out justification:
+<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
+<!--- This section can be left empty if you're not opting out of the E2E requirement -->

--- a/.github/workflows/check-e2e-update-requirement.yaml
+++ b/.github/workflows/check-e2e-update-requirement.yaml
@@ -1,0 +1,177 @@
+name: Check requirement to update E2E test suite
+on:
+  pull_request:
+    types: [ opened, synchronize, edited ]
+    paths:
+      - 'bundle/**'
+      - 'config/**'
+      - 'Dockerfiles/**'
+      - 'internal/**'
+      - 'pkg/**'
+      - 'cmd/main.go'
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+
+jobs:
+  check-e2e-update-requirement:
+    name: Check requirement to update E2E test suite
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Save PR info
+        run: |
+          echo "${{ github.event.number }}" > pr_number.txt
+          echo "${{ github.event.pull_request.user.login }}" > pr_author.txt
+
+      - name: Check requirement to update E2E test suite
+        id: check-e2e
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const { owner, repo } = context.repo;
+            const prNumber = context.issue.number;
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: prNumber,
+            });
+
+            const prBody = pr.body || '';
+            const skipE2eChecked = /- \[x\]\s*Skip requirement to update E2E test suite for this PR/i.test(prBody);
+            
+            console.log(`Skip e2e checkbox checked: ${skipE2eChecked}`);
+            
+            let checkResult = {
+              status: 'success',
+              reason: '',
+              needsComment: false,
+              commentType: ''
+            };
+            
+            if (skipE2eChecked) {
+              console.log('Skip e2e checkbox is checked, looking for justification in PR description...');
+              
+              const validateJustification = (text) => {
+                // Create regex for the PR description title level (#### is used in PR description)
+                const titleRegex = new RegExp(`^\\s*####\\s*E2E update requirement opt-out justification:\\s*$`, 'im');
+                const titleMatch = text.match(titleRegex);
+                
+                if (!titleMatch) {
+                  return false;
+                }
+                
+                // Get the justification content below the title
+                const titleIndex = titleMatch.index + titleMatch[0].length;
+                const contentAfterTitle = text.substring(titleIndex);
+                
+                // find the next title at same or higher depth => this will determine the end of the justification content
+                const nextTitleRegex = /^\\s*#{1,4}\\s+/m;
+                const nextTitleMatch = contentAfterTitle.match(nextTitleRegex);
+                
+                let justificationContent;
+                if (nextTitleMatch) {
+                  // next title found => get content only until this next title
+                  justificationContent = contentAfterTitle.substring(0, nextTitleMatch.index);
+                } else {
+                  // no next title found => take all the remaining content
+                  justificationContent = contentAfterTitle;
+                }
+                
+                // check if there's a non-empty justification comment - ignoring whitespace, HTML comments, and empty lines
+                const justificationComment = justificationContent
+                  .replace(/<!--[\s\S]*?-->/g, '')
+                  .replace(/^\s*$/gm, '')
+                  .trim();
+                
+                return justificationComment.length > 0;
+              };
+              
+              // Check if justification is provided in PR description
+              const prDescriptionHasJustification = validateJustification(prBody);
+              console.log(`Justification found in PR description: ${prDescriptionHasJustification}`);
+              
+              if (!prDescriptionHasJustification) {
+                console.log('❌ FAILURE: PR author opted-out of the E2E test suite update requirement, but no justification was found in PR description');
+                checkResult = {
+                  status: 'failure',
+                  reason: 'PR author opted-out of the E2E test suite update requirement, but no justification was found in PR description',
+                  needsComment: true,
+                  commentType: 'missing_justification'
+                };
+              } else {
+                console.log(`Found justification from PR author`);
+                console.log('✅ SUCCESS: PR author opted-out of the E2E test suite update requirement and provided a justification');
+                checkResult = {
+                  status: 'success',
+                  reason: 'PR author opted-out of the E2E test suite update requirement and provided a justification',
+                  needsComment: false,
+                  commentType: ''
+                };
+              }
+            } else {
+              // skip e2e update requirement checkbox is not checked
+              // => verify e2e tests were added/updated
+              console.log('Requirement to update E2E test suite was is not set to be skipped, checking for e2e test updates in the PR...');
+              
+              const { data: files } = await github.rest.pulls.listFiles({
+                owner,
+                repo,
+                pull_number: prNumber,
+              });
+              
+              // Check if any files in tests/e2e directory were modified
+              const e2eFilesModified = files.some(file => 
+                file.filename.startsWith('tests/e2e/') && 
+                ['added', 'modified', 'renamed'].includes(file.status)
+              );
+              
+              console.log(`E2E files modified: ${e2eFilesModified}`);
+              console.log('Modified files:', files.map(f => f.filename).join(', '));
+              
+              if (!e2eFilesModified) {
+                console.log('❌ FAILURE: No e2e tests updated and skip checkbox not checked');
+                checkResult = {
+                  status: 'failure',
+                  reason: 'No e2e tests updated and skip checkbox not checked',
+                  needsComment: true,
+                  commentType: 'missing_e2e_tests'
+                };
+              } else {
+                console.log('✅ SUCCESS: E2E tests were added/updated in the PR');
+                checkResult = {
+                  status: 'success',
+                  reason: 'E2E tests were added/updated in the PR',
+                  needsComment: false,
+                  commentType: ''
+                };
+              }
+            }
+            
+            // save results to files for the comment workflow
+            fs.writeFileSync('check_result.json', JSON.stringify(checkResult));
+            
+            if (checkResult.status === 'failure') {
+              core.setFailed(`❌ FAILURE: ${checkResult.reason}`);
+            } else {
+              console.log('✅ SUCCESS: E2E requirement check passed');
+            }
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-check-results
+          path: |
+            pr_number.txt
+            pr_author.txt
+            check_result.json

--- a/.github/workflows/comment-on-e2e-check.yaml
+++ b/.github/workflows/comment-on-e2e-check.yaml
@@ -1,0 +1,131 @@
+name: Comment on E2E requirement check
+on:
+  workflow_run:
+    workflows: ["Check requirement to update E2E test suite"]
+    types:
+      - completed
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  download-artifact-data:
+    runs-on: ubuntu-latest
+    outputs:
+      pr_number: ${{ steps.artifact-data.outputs.pr_number }}
+      pr_author: ${{ steps.artifact-data.outputs.pr_author }}
+      check_result: ${{ steps.artifact-data.outputs.check_result }}
+    steps:
+      - name: Download artifact
+        id: artifact-download
+        uses: actions/github-script@v7
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "e2e-check-results"
+            })[0];
+
+            if (!matchArtifact) {
+              core.notice('No e2e-check-results artifact found; skipping comment workflow.');
+              core.setOutput('found', 'false');
+              return;
+            }
+
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/e2e-check-results.zip`, Buffer.from(download.data));
+            core.setOutput('found', 'true');
+      - name: Unzip artifact
+        if: steps.artifact-download.outputs.found == 'true'
+        run: unzip -o e2e-check-results.zip
+      - name: Extract data
+        if: steps.artifact-download.outputs.found == 'true'
+        id: artifact-data
+        run: |
+          echo "pr_number=$(head -n 1 pr_number.txt)" >> $GITHUB_OUTPUT
+          echo "pr_author=$(head -n 1 pr_author.txt)" >> $GITHUB_OUTPUT
+          echo "check_result=$(cat check_result.json)" >> $GITHUB_OUTPUT
+
+  comment-on-pr:
+    needs:
+      - download-artifact-data
+    if: ${{ needs.download-artifact-data.outputs.pr_number != '' }}
+    runs-on: ubuntu-latest
+    permissions: 
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Parse check result
+        id: parse-result
+        run: |
+          echo '${{ needs.download-artifact-data.outputs.check_result }}' > check_result.json
+          NEEDS_COMMENT=$(jq -r '.needsComment' check_result.json)
+          COMMENT_TYPE=$(jq -r '.commentType' check_result.json)
+          echo "needs_comment=${NEEDS_COMMENT}" >> $GITHUB_OUTPUT
+          echo "comment_type=${COMMENT_TYPE}" >> $GITHUB_OUTPUT
+
+      - name: Comment on PR - Missing Justification case
+        if: steps.parse-result.outputs.needs_comment == 'true' && steps.parse-result.outputs.comment_type == 'missing_justification'
+        uses: thollander/actions-comment-pull-request@v3.0.1
+        with:
+          message: |
+            ## ❌ E2E Update Requirement Check Failed
+
+            You have checked the "Skip requirement to update E2E test suite for this PR" checkbox, but no justification was found in the PR description.
+
+            **Action required from the PR author:**
+            1. Edit the PR description and add your justification in the `#### E2E update requirement opt-out justification` section
+               - **Note:** In case you deleted the `### E2E test suite update requirement` part of the original template description (or any of it subparts), you can find the original template in `.github/PULL_REQUEST_TEMPLATE.md`, and restore the deleted part from there
+            2. Submit the PR description changes. This will automatically re-trigger the check
+
+            **For more info, please refer to:** [workflow run details](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }})
+          pr-number: ${{ needs.download-artifact-data.outputs.pr_number }}
+          comment-tag: e2e-check-error
+
+      - name: Comment on PR - Missing E2E Tests case
+        if: steps.parse-result.outputs.needs_comment == 'true' && steps.parse-result.outputs.comment_type == 'missing_e2e_tests'
+        uses: thollander/actions-comment-pull-request@v3.0.1
+        with:
+          message: |
+            ## ❌ E2E Update Requirement Check Failed
+
+            No e2e tests were added/updated as part of this PR.
+
+            **Action required from the PR author:** Please either:
+            1. Add or update e2e tests relevant to the PR changes in the `tests/e2e/` directory, OR
+            2. Evaluate the possibility of opting-out of this requirement:
+               1. Inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md), to determine if the nature of the PR changes allows for skipping this requirement
+               2. If opt-out is applicable, please proceed to provide justification in the PR description (`#### E2E update requirement opt-out justification:` section)
+                  - **Note:** In case you previously deleted the `### E2E test suite update requirement` part of the original template description (or any of it subparts), you can find the original template in `.github/PULL_REQUEST_TEMPLATE.md`, and restore the deleted part from there
+               3. After adding the justification, check the "Skip requirement to update E2E test suite for this PR" checkbox
+               4. Submit/save changes to the PR description. The check will be triggered automatically and should pass
+
+            **For more info, please refer to:** [workflow run details](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }})
+
+            **Why this check exists:**
+            - E2E tests help ensure that changes work correctly in a real environment and don't break existing functionality
+            - by default, every code-related PR should include an extension/update to the E2E test suite to cover the new changes
+            - if the PR author is in doubt whether this requirement is applicable for their PR, please refer to the PR template for guidance about appropriate/inappropriate cases for opting-out
+          pr-number: ${{ needs.download-artifact-data.outputs.pr_number }}
+          comment-tag: e2e-check-error
+
+      - name: Clean up error comments for missing justification when check passes
+        if: steps.parse-result.outputs.needs_comment == 'false' || github.event.workflow_run.conclusion == 'success'
+        uses: thollander/actions-comment-pull-request@v3.0.1
+        with:
+          pr-number: ${{ needs.download-artifact-data.outputs.pr_number }}
+          comment-tag: e2e-check-error
+          mode: delete
+          create-if-not-exists: false

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -181,7 +181,13 @@ func LoadConfig() (*OperatorConfig, error) {
 	return &operatorConfig, nil
 }
 
+func foo() {
+	fmt.Println("Trust me,I'm definitely a very important function for the Operator and totally not a placeholder")
+}
+
 func main() { //nolint:funlen,maintidx,gocyclo
+	foo()
+
 	// Viper settings
 	viper.SetEnvPrefix("ODH_MANAGER")
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))

--- a/docs/e2e-update-requirement-guidelines.md
+++ b/docs/e2e-update-requirement-guidelines.md
@@ -1,0 +1,33 @@
+# E2E Test Suite Update Requirement Guidelines
+
+When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly. A dedicated GitHub Action check is in place to enforce this requirement.
+
+It is possible to opt-out of this check with proper justification. Please refer to the guidelines below to determine whether your PR justifies skipping this check, and how to do it (if applicable).
+
+### Appropriate cases for opting-out of the E2E test suite update requirement:
+
+- Documentation-only changes (README, comments, etc.)
+- Unit test additions/modifications without functional changes
+- Code style/formatting changes
+- Dependency version updates without functional impact
+- Build system changes that do not affect runtime behavior
+- Non-functional refactoring with existing test coverage
+
+### NOT Appropriate cases for opting-out of E2E test suite update requirement:
+
+- New feature implementation
+- Bug fixes affecting user-facing functionality
+- API changes or modifications
+- Configuration changes affecting deployment
+- Changes to controllers, operators, or core logic
+- Cross-component integration modifications
+- Changes affecting user workflows or UI
+
+### Opt-out guide
+**Note:** This particular guide is also present in the PR template/description
+
+1. Inspect the above-mentioned guidelines, to determine if the nature of the PR changes allows for skipping this requirement
+2. Provide justification in the PR description under the `#### E2E update requirement opt-out justification` section
+   - **Note:** In case you previusly deleted the `### E2E test suite update requirement` part of the original template description (or any of it subparts), you can find the original template in `.github/PULL_REQUEST_TEMPLATE.md`, and restore the deleted part from there
+3. Check the `Skip requirement to update E2E test suite for this PR` checkbox
+4. Submit/save these changes to the PR description. This will automatically trigger the check.

--- a/tests/e2e/creation_test.go
+++ b/tests/e2e/creation_test.go
@@ -59,6 +59,8 @@ func dscManagementTestSuite(t *testing.T) {
 		TestContext: tc,
 	}
 
+	fooTest()
+
 	// Define test cases.
 	testCases := []TestCase{
 		{"Ensure Service Mesh , Serverless and Observability operators are installed", dscTestCtx.ValidateOperatorsInstallation},
@@ -93,6 +95,10 @@ func dscManagementTestSuite(t *testing.T) {
 
 	// Run the test suite.
 	RunTestCases(t, testCases)
+}
+
+func fooTest() {
+	fmt.Println("I'm a test function that is totally not a placeholder either")
 }
 
 // ValidateOperatorsInstallation ensures the Service Mesh and Serverless operators are installed.

--- a/tests/e2e/creation_test.go
+++ b/tests/e2e/creation_test.go
@@ -59,8 +59,6 @@ func dscManagementTestSuite(t *testing.T) {
 		TestContext: tc,
 	}
 
-	fooTest()
-
 	// Define test cases.
 	testCases := []TestCase{
 		{"Ensure Service Mesh , Serverless and Observability operators are installed", dscTestCtx.ValidateOperatorsInstallation},
@@ -95,10 +93,6 @@ func dscManagementTestSuite(t *testing.T) {
 
 	// Run the test suite.
 	RunTestCases(t, testCases)
-}
-
-func fooTest() {
-	fmt.Println("I'm a test function that is totally not a placeholder either")
 }
 
 // ValidateOperatorsInstallation ensures the Service Mesh and Serverless operators are installed.


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification:

### Not a justification

