### PR TITLE
demo

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -181,7 +181,13 @@ func LoadConfig() (*OperatorConfig, error) {
 	return &operatorConfig, nil
 }
 
+func foo() {
+	fmt.Println("Trust me,I'm definitely a very important function for the Operator and totally not a placeholder")
+}
+
 func main() { //nolint:funlen,maintidx,gocyclo
+	foo()
+
 	// Viper settings
 	viper.SetEnvPrefix("ODH_MANAGER")
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))


### PR DESCRIPTION
### Description

This PR adds comprehensive debug utilities to the E2E test framework to automatically diagnose test failures and timeouts. When any E2E test fails (due to panics, timeouts, or assertion failures), the system now automatically collects and displays detailed cluster diagnostics to help quickly identify root causes.

-----

### Key Features:

  * **Automatic activation** on any test failure type (panics, timeouts, assertions)
  * **Multi-level integration** at test main, test group, and individual test case levels
  * **Comprehensive cluster diagnostics** including node health, resource usage, deployment status, recent events, and resource quotas
  * **Zero configuration required** - automatically sets up when `NewTestContext()` is called

-----

### Files Added:

  * `tests/e2e/debug_utils_test.go` - Core debug utilities with cluster diagnostics
  * Integrated into `tests/e2e/controller_test.go`, `tests/e2e/helper_test.go`, and `tests/e2e/test_context_test.go`

This addresses the debugging challenges we've encountered with deployment recreation failures (like ModelRegistry timeouts) and resource exhaustion issues by providing immediate, detailed cluster state information.

[https://issues.redhat.com/browse/RHOAIENG-23354](https://issues.redhat.com/browse/RHOAIENG-23354)

-----

### How Has This Been Tested?

  * **Tested with intentional panic** - Verified debug utilities activate and provide comprehensive cluster diagnostics
  * **Tested with timeout simulation** - Confirmed timeout failures trigger debug output at both test case and test suite levels
  * **Verified multi-level integration** - Debug handlers work correctly at test suite, test group, and individual test case levels
  * **Linting and code quality** - All files pass golangci-lint with no errors, using existing Kubernetes constants
  * **API testing** - Simplified `HandleTestFailure` API for better usability and cleaner codebase integration

-----

### Example diagnostic output:

```
TEST FAILURE DETECTED: trustyai
Running comprehensive cluster diagnostics...
=== CLUSTER STATE ===
Node: master-0 - CPU: 3500m/4 (87.5% available), Memory: 15219888Ki/16370864Ki (93.0% available)
=== NAMESPACE RESOURCES ===
=== OPERATOR STATUS ===
=== DSCI/DSC STATUS ===
=== RECENT EVENTS (last 5 minutes) ===
=== RESOURCE QUOTAS ===
Diagnostics complete for failed test: trustyai
```

-----

### Screenshot or short clip

-----

### Merge criteria

  * [x] You have read the [[contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md)](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
  * [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
  * [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
  * [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
  * [x] The developer has manually tested the changes and verified that the changes work
 
### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification:
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
refactor

-----

### Summary by CodeRabbit

  * Tests

  * Added global and per-test panic handling that triggers automated diagnostics on panic or failure, capturing cluster state, namespaces, operator/DSCI/DSC health, recent events, and quotas to speed triage.

  * Initialized a shared diagnostics client and deduplicated diagnostics runs so each diagnostic pipeline runs once per key.

  * Added hooks to run diagnostics on subtest failures and after test context initialization.

  * Removed a redundant success condition from two resource-creation checks.

  * Bug Fixes

  * Unknown deletion policies now fail tests with a clear error instead of exiting the process.